### PR TITLE
Fix `couldn't get resource list for custom.metrics.k8s.io/v1beta1`

### DIFF
--- a/manifests/applications/prometheus-adapter.yaml
+++ b/manifests/applications/prometheus-adapter.yaml
@@ -13,9 +13,9 @@ spec:
       version: v3
       values: |
         prometheus:
-          url: http://vmsingle-database.victoriametrics.svc
-          port: 8429
-          path: "/"
+          url: http://prometheus-kube-prometheus-prometheus.prometheus.svc
+          port: 9090
+          path: ""
         rules:
           default: true
           custom: []


### PR DESCRIPTION
- VictoriaMetrics said "the number of matching timeseries exceeds 30000"
- Use prometheus instead of VictoriaMetrics